### PR TITLE
update security policy to be compatible with async reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-keyless</artifactId>
-    <version>1.5.1</version>
+    <version>1.6.0-8238-entrypoint-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - Keyless Security</name>
     <description>Description of the Keyless Security Gravitee Policy</description>
@@ -34,8 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.1</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.33.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.6</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.38.0-8238-entrypoint-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
 
@@ -156,7 +156,7 @@
                 <artifactId>prettier-maven-plugin</artifactId>
                 <version>0.18</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
+                    <nodeVersion>16.16.0</nodeVersion>
                     <prettierJavaVersion>1.0.1</prettierJavaVersion>
                 </configuration>
                 <executions>

--- a/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
+++ b/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
@@ -18,6 +18,8 @@ package io.gravitee.policy.keyless;
 import static io.gravitee.gateway.jupiter.api.context.ExecutionContext.ATTR_APPLICATION;
 import static io.gravitee.gateway.jupiter.api.context.ExecutionContext.ATTR_SUBSCRIPTION_ID;
 
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.gateway.jupiter.api.policy.SecurityPolicy;
 import io.gravitee.policy.v3.keyless.KeylessPolicyV3;
@@ -48,12 +50,21 @@ public class KeylessPolicy extends KeylessPolicyV3 implements SecurityPolicy {
     }
 
     @Override
-    public Single<Boolean> support(RequestExecutionContext ctx) {
+    public Single<Boolean> support(HttpExecutionContext ctx) {
         return TRUE;
     }
 
     @Override
     public Completable onRequest(RequestExecutionContext ctx) {
+        return handleSecurity(ctx);
+    }
+
+    @Override
+    public Completable onMessageRequest(final MessageExecutionContext ctx) {
+        return handleSecurity(ctx);
+    }
+
+    private Completable handleSecurity(final HttpExecutionContext ctx) {
         return Completable.fromRunnable(
             () -> {
                 ctx.setAttribute(ATTR_APPLICATION, APPLICATION_NAME_ANONYMOUS);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8009

**Description**

Update policy to handle new message execution context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-8238-entrypoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/1.6.0-8238-entrypoint-SNAPSHOT/gravitee-policy-keyless-1.6.0-8238-entrypoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
