### PR TITLE
fix: take care of previously extracted SecurityToken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
 
     <properties>
         <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.44.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.44.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
         <gravitee-expression-language.version>1.11.0</gravitee-expression-language.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.20.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.19.0-alpha.2-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8498


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.1-issues-8498-jupiter-apikey-fallback-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/1.8.1-issues-8498-jupiter-apikey-fallback-SNAPSHOT/gravitee-policy-keyless-1.8.1-issues-8498-jupiter-apikey-fallback-SNAPSHOT.zip)
  <!-- Version placeholder end -->
