### PR TITLE
Bump rx java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,13 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.44.1</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.7</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.0.0-alpha.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-expression-language.version>1.11.0</gravitee-expression-language.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.19.0-alpha.2-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-node.version>1.25.0</gravitee-node.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-expression-language.version>2.0.0-alpha.2</gravitee-expression-language.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
+        <gravitee-common.version>2.0.0-alpha.1</gravitee-common.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
 

--- a/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
+++ b/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
@@ -22,8 +22,8 @@ import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.policy.SecurityPolicy;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
 import io.gravitee.policy.v3.keyless.KeylessPolicyV3;
-import io.reactivex.Completable;
-import io.reactivex.Maybe;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
@@ -27,7 +27,7 @@ import io.gravitee.gateway.jupiter.api.context.ContextAttributes;
 import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.Request;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7990
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bumpRxJava-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/2.0.0-bumpRxJava-SNAPSHOT/gravitee-policy-keyless-2.0.0-bumpRxJava-SNAPSHOT.zip)
  <!-- Version placeholder end -->
