### PR TITLE
fix: bump gateway api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,11 @@
 
     <properties>
         <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.11</gravitee-gateway-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.20.0-alpha.2-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
@@ -85,6 +86,11 @@
                 <version>${gravitee-gateway-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.gravitee.reporter</groupId>
+                <artifactId>gravitee-reporter-api</artifactId>
+                <version>${gravitee-reporter-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.gravitee.connector</groupId>
                 <artifactId>gravitee-connector-api</artifactId>
                 <version>${gravitee-connector-api.version}</version>
@@ -102,6 +108,12 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.reporter</groupId>
+            <artifactId>gravitee-reporter-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
**Description**

Bump gateway api version to use the latest Metric object
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-bump-gateway-api-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/2.0.1-bump-gateway-api-version-SNAPSHOT/gravitee-policy-keyless-2.0.1-bump-gateway-api-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
