### PR TITLE
fix: bump gateway-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.7</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.9</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>3.1.0-alpha.10</gravitee-node.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>

--- a/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
@@ -95,7 +95,19 @@ class KeylessPolicyTest {
     @EnumSource(value = SecurityToken.TokenType.class, names = { "CLIENT_ID", "API_KEY" })
     @DisplayName("Should return an empty Maybe if there was a SecurityToken extracted by the previous plan")
     void shouldReturnAnEmptyWhenExtractingSecurityToken(SecurityToken.TokenType type) {
-        when(ctx.getInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN)).thenReturn(new SecurityToken(type, "tokenValue"));
+        when(ctx.getInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN))
+            .thenReturn(SecurityToken.builder().tokenType(type.name()).tokenValue("tokenValue").build());
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertNoValues();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SecurityToken.TokenType.class, names = { "CLIENT_ID", "API_KEY" })
+    @DisplayName("Should return an empty Maybe if there was an invalid SecurityToken extracted by the previous plan")
+    void shouldReturnAnEmptyWhenExtractingInvalidSecurityToken(SecurityToken.TokenType type) {
+        when(ctx.getInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN))
+            .thenReturn(SecurityToken.builder().tokenType(type.name()).invalid(true).build());
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertNoValues();


### PR DESCRIPTION
**Description**

Bump gateway api version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-bump-apim-versions-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/3.0.0-bump-apim-versions-SNAPSHOT/gravitee-policy-keyless-3.0.0-bump-apim-versions-SNAPSHOT.zip)
  <!-- Version placeholder end -->
