### PR TITLE
Update policy for kafka gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,9 @@
-**Issue**
+## Issue
 
-https://gravitee.atlassian.net/browse/APIM-XXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
-
-<!-- Add any other context about the PR here -->
-<!-- It can be links to other PRs or docs or drawing -->
-<!-- Or reproduction steps in case of bug fix -->
+## Additional context

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,8 @@ It sets multiple attributes during policy execution, as follows:
 |Plugin version | APIM version
 
 |1.x            | Up to 3.20
-|3.x            | 4.0 to latest
+|3.x            | 4.0 to 4.5
+|4.x            | 4.6 to latest
 
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.2.3</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
 
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
@@ -52,32 +47,17 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.common</groupId>
-                <artifactId>gravitee-common</artifactId>
-                <version>${gravitee-common.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!-- Provided scope -->
+        <!-- Gravitee.io dependencies -->
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>

--- a/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
+++ b/src/main/java/io/gravitee/policy/keyless/KeylessPolicy.java
@@ -19,8 +19,10 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityPolicy;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
 import io.gravitee.policy.v3.keyless.KeylessPolicyV3;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -29,7 +31,7 @@ import io.reactivex.rxjava3.core.Maybe;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class KeylessPolicy extends KeylessPolicyV3 implements SecurityPolicy {
+public class KeylessPolicy extends KeylessPolicyV3 implements HttpSecurityPolicy {
 
     @Override
     public String id() {
@@ -47,7 +49,7 @@ public class KeylessPolicy extends KeylessPolicyV3 implements SecurityPolicy {
     }
 
     @Override
-    public Maybe<SecurityToken> extractSecurityToken(HttpExecutionContext ctx) {
+    public Maybe<SecurityToken> extractSecurityToken(HttpPlainExecutionContext ctx) {
         // This token is present in internal attributes if a previous SecurityPolicy has extracted a SecurityToken
         final SecurityToken securityToken = ctx.getInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
         // If it is present with a type different from NONE, then we should not execute this KeylessPlan.
@@ -58,11 +60,11 @@ public class KeylessPolicy extends KeylessPolicyV3 implements SecurityPolicy {
     }
 
     @Override
-    public Completable onRequest(HttpExecutionContext ctx) {
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
         return handleSecurity(ctx);
     }
 
-    private Completable handleSecurity(final HttpExecutionContext ctx) {
+    private Completable handleSecurity(final HttpPlainExecutionContext ctx) {
         return Completable.fromRunnable(() -> {
             ctx.setAttribute(ContextAttributes.ATTR_APPLICATION, APPLICATION_NAME_ANONYMOUS);
             ctx.setAttribute(ContextAttributes.ATTR_SUBSCRIPTION_ID, ctx.request().remoteAddress());

--- a/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,10 +49,10 @@ class KeylessPolicyTest {
     protected static final String REMOTE_ADDRESS = "remoteAddress";
 
     @Mock
-    private Request request;
+    private HttpRequest request;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private HttpPlainExecutionContext ctx;
 
     private KeylessPolicy cut;
 

--- a/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/keyless/KeylessPolicyTest.java
@@ -24,10 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,9 +46,6 @@ class KeylessPolicyTest {
     protected static final String REMOTE_ADDRESS = "remoteAddress";
 
     @Mock
-    private HttpRequest request;
-
-    @Mock
     private HttpPlainExecutionContext ctx;
 
     private KeylessPolicy cut;
@@ -63,8 +57,7 @@ class KeylessPolicyTest {
 
     @Test
     void shouldSetContextAttributes() {
-        when(ctx.request()).thenReturn(request);
-        when(request.remoteAddress()).thenReturn(REMOTE_ADDRESS);
+        when(ctx.remoteAddress()).thenReturn(REMOTE_ADDRESS);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

- use new HttpSecurityPolicy and BaseExecutionContext interface (BREAKING CHANGE: requires APIM 4.6+)
- implements kafka seurity policy
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-APIM-7143-impl-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-keyless/4.0.0-APIM-7143-impl-security-chain-SNAPSHOT/gravitee-policy-keyless-4.0.0-APIM-7143-impl-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
